### PR TITLE
Validate or coerce PR urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ pub build extension
 
 Install the `build/extension/` directory.
 
+## Test
+
+```
+alias ddev='pub run dart_dev'
+ddev gen-test-runner
+ddev test -p content-shell
+```
+
 ## Credits
 
 Icon courtesy of [Herbert Spencer](https://thenounproject.com/hspencer/)

--- a/extension/popup.dart
+++ b/extension/popup.dart
@@ -21,8 +21,8 @@ Future<Null> updateToken(String token) async {
 Future<Null> main() async {
   react_client.setClientConfiguration();
   String url = await currentUrl();
-  Map<String, String> data = await chrome.storage.local.get({'hipchat-token': ''});
-  adapter.token = data['hipchat-token'];
+  Map<String, dynamic> data = await chrome.storage.local.get({'hipchat-token': ''});
+  adapter.token = data['hipchat-token'] as String;
   final container = querySelector('#container');
   final popup = (Popup()..bender = adapter..currentUrl = url..updateTokenCallback = updateToken)();
   react_dom.render(popup,

--- a/lib/src/bender_adapter.dart
+++ b/lib/src/bender_adapter.dart
@@ -11,10 +11,12 @@ class BenderAdapter {
   Map<String, String> get headers => {'Authorization': 'Bearer $token'};
 
   Future<Null> createTicket(String url) async {
+    url = validateAndCoerceToPullRequestUrl(url);
     await sendMessage('ticket $url');
   }
 
   Future<Null> monitorPullRequest(String url) async {
+    url = validateAndCoerceToPullRequestUrl(url);
     await sendMessage('monitor pr $url');
   }
 
@@ -25,4 +27,17 @@ class BenderAdapter {
       throw new Exception('Sending message failed: ${request.statusText}');
     }
   }
+}
+
+String validateAndCoerceToPullRequestUrl(String url) {
+  if (url == null) {
+    throw new ArgumentError.notNull('url');
+  }
+  final re = new RegExp(r'(https://github\.com/.*/pull/\d+).*');
+  String prUrl = re.allMatches(url)?.first?.group(1);
+  if (prUrl == null) {
+    throw new ArgumentError.value(
+        url, 'url', 'Not a PR url; does not match $re');
+  }
+  return prUrl;
 }

--- a/lib/src/components/action_block.dart
+++ b/lib/src/components/action_block.dart
@@ -12,7 +12,6 @@ class ActionBlockProps extends UiProps {
   Map<String, bool> flags;
   bool isActive;
   Map<String, String> parameters;
-  String title;
 }
 
 @Component()

--- a/test/bendium_test.dart
+++ b/test/bendium_test.dart
@@ -4,16 +4,14 @@
 import 'package:bendium/bendium.dart';
 import 'package:test/test.dart';
 
+@TestOn('browser')
 void main() {
-  group('A group of tests', () {
-    Awesome awesome;
-
-    setUp(() {
-      awesome = new Awesome();
-    });
-
-    test('First Test', () {
-      expect(awesome.isAwesome, isTrue);
+  group('validateAndCoerceToPullRequestUrl', () {
+    test('extracts just the PR url', () {
+      String expected = 'https://github.com/Workiva/w_viewer/pull/197';
+      String extraneousPrUrl = '$expected/files?monkey#issuecomment-283103917';
+      String actual = validateAndCoerceToPullRequestUrl(extraneousPrUrl);
+      expect(actual, equals(expected));
     });
   });
 }


### PR DESCRIPTION
## Problem
![image](https://cloud.githubusercontent.com/assets/6391742/23467628/d2c51d08-fe5b-11e6-9042-dbdcc4d91861.png)

## Solution
Validate and strip extraneous url stuff. Also, Fix analyzer warning about overriding `title` and implicit cast. And add test instructions to readme.

## Testing
Unit test added.
* Run bendium command from the PR page with an anchor and/or query param in the url; should just send the `/pull/123` url to Bender.
* Run in the commits and files pages; should work as well.

Interestingly, Bender seemed to work ok on the commits and files pages even without this change, so it must be doing some stripping of its own:
![image](https://cloud.githubusercontent.com/assets/6391742/23467803/3e59774e-fe5c-11e6-91d7-ec9c00f095d3.png)

@georgelesica-wf 