### PR TITLE
Add a Release Action

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -1,5 +1,7 @@
 import 'package:bendium/src/action.dart';
 
+final RegExp _repoRegex = new RegExp(r'https://github\.com/Workiva/([^/?]+)');
+
 String validateAndCoerceToPullRequestUrl(String url) {
   print('validateAndCoerceToPullRequestUrl $url');
   if (url == null) {
@@ -15,6 +17,21 @@ String validateAndCoerceToPullRequestUrl(String url) {
   if (prUrl == null) {
     throw new ArgumentError.value(
         url, 'url', 'Not a PR url; does not match $re');
+  }
+  return prUrl;
+}
+
+String validateAndExtractRepoName(String url) {
+  if (url == null) {
+    throw new ArgumentError.notNull('url');
+  }
+  String prUrl;
+  try {
+    prUrl = _repoRegex.allMatches(url)?.first?.group(1);
+  } catch (_) {}
+  if (prUrl == null) {
+    throw new ArgumentError.value(
+        url, 'url', 'Not a repository url; does not match $_repoRegex');
   }
   return prUrl;
 }
@@ -73,6 +90,15 @@ final Action dartFormat = new Action(
   title: 'Run Dart Format',
 );
 
+final Action cutRelease = new Action(
+  getMessage: (String url) {
+    var repoName = validateAndExtractRepoName(url);
+    return 'release $repoName';
+  },
+  isActive: (String url) => url.startsWith(_repoRegex),
+  title: 'Cut Release',
+);
+
 /// List of actions registered with the extension.
 ///
 /// To add new actions, simply add them to this list.
@@ -83,4 +109,5 @@ final Iterable<Action> actions = <Action>[
   mergeMaster,
   updateGolds,
   dartFormat,
+  cutRelease,
 ];

--- a/test/bendium_test.dart
+++ b/test/bendium_test.dart
@@ -14,4 +14,26 @@ void main() {
       expect(actual, equals(expected));
     });
   });
+
+  group('validateAndExtractRepoName', () {
+    test('extracts just the repo name', () {
+      String url = 'https://github.com/Workiva/w_common';
+      expect(validateAndExtractRepoName(url), 'w_common');
+    });
+
+    test('ignores subsequent path segments', () {
+      String url = 'https://github.com/Workiva/w_common/pull/197';
+      expect(validateAndExtractRepoName(url), 'w_common');
+    });
+
+    test('ignores query parameters', () {
+      String url = 'https://github.com/Workiva/w_common?blah=true';
+      expect(validateAndExtractRepoName(url), 'w_common');
+    });
+
+    test('does not match non-Workiva forks', () {
+      String url = 'https://github.com/georgelesica-wf/w_common';
+      expect(() => validateAndExtractRepoName(url), throwsArgumentError);
+    });
+  });
 }


### PR DESCRIPTION
It would be nice when sitting on a web page in a Workiva repository to be able to cut a release of that package. So I've added a bendium action to do just that!

Tested locally to kick off this release PR: https://github.com/Workiva/key_binder/pull/73