### PR TITLE
Add keys and fix checkbox event handling, fixes #24

### DIFF
--- a/lib/src/components/action_block.dart
+++ b/lib/src/components/action_block.dart
@@ -55,7 +55,7 @@ class ActionBlockComponent
               props.action.parameterName,
               (Dom.input()
                 ..type = 'checkbox'
-                ..onChange = _onParameterChange
+                ..onChange = _onBooleanParameterChange
                 ..checked = state.parameterValue == 'true'
                 ..value = state.parameterValue)());
           break;
@@ -84,6 +84,13 @@ class ActionBlockComponent
   void _handleActionTriggerClick(_) {
     props.bender
         .sendMessage(props.action.getMessage(props.url, state.parameterValue));
+  }
+
+  void _onBooleanParameterChange(SyntheticFormEvent event) {
+    CheckboxInputElement target = event.target;
+    String value = target.checked ? 'true' : null;
+    setState(newState()..parameterValue = value);
+    props.updateParameterValueCallback(value);
   }
 
   void _onParameterChange(SyntheticFormEvent event) {

--- a/lib/src/components/popup.dart
+++ b/lib/src/components/popup.dart
@@ -43,12 +43,15 @@ class PopupComponent extends UiComponent<PopupProps> {
       actionBlocks.add((ActionBlock()
         ..action = action
         ..bender = props.bender
+        ..key = action.commandKey
         ..url = props.currentUrl
         ..updateParameterValueCallback =
             props.updateParameterValueCallbackFactory(action))());
     }
 
-    actionBlocks.add((Dom.div()..className = 'config')(
+    actionBlocks.add((Dom.div()
+          ..className = 'config'
+          ..key = 'update-hipchat-token')(
         (Dom.input()
           ..className = 'action-field'
           ..type = 'text'


### PR DESCRIPTION
The event handler for clicking a checkbox took the new value directly from the target element, which meant (obviously in hindsight) that you could never set it to "checked".

I also addressed the separate issue of the missing keys reported in the referenced issue.

### Testing

Build it, make sure the checkboxes work. No warnings in the console.