### PR TITLE
Add a notification when the token updates

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,6 +31,7 @@
 
   "permissions": [
     "activeTab",
+    "notifications",
     "tabs",
     "storage",
     "https://workiva.hipchat.com/v2/user/@Bender/message"

--- a/extension/popup.dart
+++ b/extension/popup.dart
@@ -11,6 +11,13 @@ import 'utils.dart';
 Future<Null> updateToken(BenderAdapter adapter, String token) async {
   await chrome.storage.local.set({'hipchat-token': token});
   adapter.token = token;
+  await chrome.notifications.create(new chrome.NotificationOptions(
+    title: 'Bendium',
+    message: 'HipChat token updated',
+    iconUrl: 'icons/icon128.png',
+    type: chrome.TemplateType.BASIC,
+
+  ));
 }
 
 UpdateParameterValueCallback updateParameterValueFactory(Action action) {


### PR DESCRIPTION
People always complain that there is no feedback when the HipChat token is updated. Let's fix that.