### PR TITLE
Make Bendium work in Firefox

### DIFF
--- a/extension/popup.dart
+++ b/extension/popup.dart
@@ -16,7 +16,6 @@ Future<Null> updateToken(BenderAdapter adapter, String token) async {
     message: 'HipChat token updated',
     iconUrl: 'icons/icon128.png',
     type: chrome.TemplateType.BASIC,
-
   ));
 }
 

--- a/extension/utils.dart
+++ b/extension/utils.dart
@@ -11,9 +11,9 @@ Future dumpTabsQueryResults(chrome.TabsQueryParams queryInfo,
 
 /// Get the url of the active tab.
 Future<String> currentUrl() async {
-  print('currentUrl');
-  chrome.Tab tab = await chrome.tabs.getSelected();
-  return tab.url;
+  List<chrome.Tab> tabs =
+      await chrome.tabs.query(new chrome.TabsQueryParams()..active = true);
+  return tabs.first.url;
 }
 
 /// Temporarily set the text of the icon.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,4 +35,3 @@ transformers:
       csp: true
   - test/pub_serve:
       $include: test/**_test.dart
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   barback: ^0.15.2
-  chrome: ^0.9.2
+  chrome: ^0.9.34
   dart_sass_transformer: ^0.5.0
   dart_to_js_script_rewriter: ^1.0.0
   pubspec: ^0.0.14


### PR DESCRIPTION
This replaces deprecated API usage with its replacement and updates to the version of chrome.dart needed for Firefox compatibility.